### PR TITLE
Add setter methods for MessageIter and DialogIter

### DIFF
--- a/lib/grammers-client/src/client/dialogs.rs
+++ b/lib/grammers-client/src/client/dialogs.rs
@@ -40,6 +40,62 @@ impl DialogIter {
         Self::from_request(client, limit, request)
     }
 
+    /// Exclude pinned dialogs from the results.
+    ///
+    /// When set to `true`, pinned dialogs will not be included in the returned list.
+    pub fn exclude_pinned(mut self, exclude: bool) -> Self {
+        self.request.exclude_pinned = exclude;
+        self
+    }
+
+    /// Set the folder ID to fetch dialogs from.
+    ///
+    /// Telegram allows organizing chats into folders. Use this to fetch dialogs
+    /// from a specific folder. Pass `None` to get dialogs from all folders.
+    pub fn folder_id(mut self, folder_id: i32) -> Self {
+        self.request.folder_id = Some(folder_id);
+        self
+    }
+
+    /// Offsets for pagination based on date.
+    ///
+    /// The date of the last message in the previous dialog list.
+    /// Used in conjunction with `offset_id` and `offset_peer` for pagination.
+    pub fn offset_date(mut self, date: i32) -> Self {
+        self.request.offset_date = date;
+        self
+    }
+
+    /// Offsets for pagination based on message ID.
+    ///
+    /// The ID of the last message in the previous dialog list.
+    /// Used in conjunction with `offset_date` and `offset_peer` for pagination.
+    pub fn offset_id(mut self, id: i32) -> Self {
+        self.request.offset_id = id;
+        self
+    }
+
+    /// Offsets for pagination based on peer.
+    ///
+    /// The peer of the last dialog in the previous dialog list.
+    /// Used in conjunction with `offset_date` and `offset_id` for pagination.
+    /// 
+    /// For the first request, use `tl::enums::InputPeer::Empty`.
+    pub fn offset_peer(mut self, peer: tl::enums::InputPeer) -> Self {
+        self.request.offset_peer = peer;
+        self
+    }
+
+    /// Sets a hash for caching purposes.
+    ///
+    /// The hash is used to detect if the dialog list has changed since the last request.
+    /// If the hash matches the current state, the server may return a NotModified result
+    /// to save bandwidth.
+    pub fn hash(mut self, hash: i64) -> Self {
+        self.request.hash = hash;
+        self
+    }
+
     /// Determines how many dialogs there are in total.
     ///
     /// This only performs a network call if `next` has not been called before.

--- a/lib/grammers-client/src/client/messages.rs
+++ b/lib/grammers-client/src/client/messages.rs
@@ -214,13 +214,54 @@ impl MessageIter {
         )
     }
 
+    /// Sets the ID of the message from which to start fetching the history.
+    ///
+    /// If a positive value is provided, the method will return only messages with IDs less than `offset_id`.
+    /// If a negative value is provided, the method will return only messages with IDs greater than `offset_id`.
     pub fn offset_id(mut self, offset: i32) -> Self {
         self.request.offset_id = offset;
         self
     }
 
+    /// Sets the date from which to start fetching the history.
+    ///
+    /// Only messages sent before this date will be returned.
     pub fn max_date(mut self, offset: i32) -> Self {
         self.request.offset_date = offset;
+        self
+    }
+
+    /// Number of list elements to be skipped, negative values are also accepted.
+    ///
+    /// This is useful for implementing pagination. For example, if you have fetched
+    /// messages 0-99 and want to fetch 100-199, you would set `add_offset` to 100.
+    pub fn add_offset(mut self, offset: i32) -> Self {
+        self.request.add_offset = offset;
+        self
+    }
+
+    /// Sets the maximum message ID to return.
+    ///
+    /// If a positive value is provided, only messages with IDs less than `max_id` will be returned.
+    pub fn max_id(mut self, id: i32) -> Self {
+        self.request.max_id = id;
+        self
+    }
+
+    /// Sets the minimum message ID to return.
+    ///
+    /// If a positive value is provided, only messages with IDs greater than `min_id` will be returned.
+    pub fn min_id(mut self, id: i32) -> Self {
+        self.request.min_id = id;
+        self
+    }
+
+    /// Sets a hash for pagination purposes.
+    ///
+    /// The hash is used for caching and detecting changes in the message history.
+    /// When the hash matches, the server may return a NotModified result.
+    pub fn hash(mut self, hash: i64) -> Self {
+        self.request.hash = hash;
         self
     }
 


### PR DESCRIPTION
## Summary
- Added missing setter methods to `MessageIter` and `DialogIter` to make query configurations fully customizable
- All methods follow the builder pattern and include comprehensive documentation based on the Telegram API specifications

## Changes

### MessageIter new methods:
- `add_offset()` - For pagination, skipping elements
- `max_id()` - Maximum message ID filter
- `min_id()` - Minimum message ID filter
- `hash()` - For caching and change detection

### DialogIter new methods:
- `exclude_pinned()` - Exclude pinned dialogs
- `folder_id()` - Filter by folder
- `offset_date()` - Pagination by date
- `offset_id()` - Pagination by message ID
- `offset_peer()` - Pagination by peer
- `hash()` - For caching and change detection

## Test plan
- [x] Code compiles successfully (`cargo check`)
- [ ] Existing tests pass
- [ ] Manual testing with example usage

🤖 Generated with [Claude Code](https://claude.ai/code)